### PR TITLE
setter for locale property for dynamic refresh

### DIFF
--- a/src/monthview.ts
+++ b/src/monthview.ts
@@ -241,7 +241,12 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnChanges
     @Input() noEventsLabel:string;
     @Input() autoSelect:boolean = true;
     @Input() markDisabled:(date:Date) => boolean;
-    @Input() locale:string;
+    @Input() _locale:string;
+    @Input()
+    set locale(locale: string) {
+      this._locale = locale;
+      this.init();
+    }
     @Input() dateFormatter:IDateFormatter;
     @Input() dir:string = "";
     @Input() lockSwipeToPrev:boolean;
@@ -272,51 +277,55 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnChanges
     }
 
     ngOnInit() {
-        if (this.dateFormatter && this.dateFormatter.formatMonthViewDay) {
-            this.formatDayLabel = this.dateFormatter.formatMonthViewDay;
-        } else {
-            let dayLabelDatePipe = new DatePipe('en-US');
-            this.formatDayLabel = function (date:Date) {
-                return dayLabelDatePipe.transform(date, this.formatDay);
-            };
-        }
+        this.initAndRefresh();
+    }
 
-        if (this.dateFormatter && this.dateFormatter.formatMonthViewDayHeader) {
-            this.formatDayHeaderLabel = this.dateFormatter.formatMonthViewDayHeader;
-        } else {
-            let datePipe = new DatePipe(this.locale);
-            this.formatDayHeaderLabel = function (date:Date) {
-                return datePipe.transform(date, this.formatDayHeader);
-            };
-        }
+    initAndRefresh(){
+      if (this.dateFormatter && this.dateFormatter.formatMonthViewDay) {
+        this.formatDayLabel = this.dateFormatter.formatMonthViewDay;
+    } else {
+        let dayLabelDatePipe = new DatePipe('en-US');
+        this.formatDayLabel = function (date:Date) {
+            return dayLabelDatePipe.transform(date, this.formatDay);
+        };
+    }
 
-        if (this.dateFormatter && this.dateFormatter.formatMonthViewTitle) {
-            this.formatTitle = this.dateFormatter.formatMonthViewTitle;
-        } else {
-            let datePipe = new DatePipe(this.locale);
-            this.formatTitle = function (date:Date) {
-                return datePipe.transform(date, this.formatMonthTitle);
-            };
-        }
+    if (this.dateFormatter && this.dateFormatter.formatMonthViewDayHeader) {
+        this.formatDayHeaderLabel = this.dateFormatter.formatMonthViewDayHeader;
+    } else {
+        let datePipe = new DatePipe(this._locale);
+        this.formatDayHeaderLabel = function (date:Date) {
+            return datePipe.transform(date, this.formatDayHeader);
+        };
+    }
 
-        if (this.lockSwipeToPrev) {
-            this.slider.lockSwipeToPrev(true);
-        }
+    if (this.dateFormatter && this.dateFormatter.formatMonthViewTitle) {
+        this.formatTitle = this.dateFormatter.formatMonthViewTitle;
+    } else {
+        let datePipe = new DatePipe(this._locale);
+        this.formatTitle = function (date:Date) {
+            return datePipe.transform(date, this.formatMonthTitle);
+        };
+    }
 
-        if (this.lockSwipes) {
-            this.slider.lockSwipes(true);
-        }
+    if (this.lockSwipeToPrev) {
+        this.slider.lockSwipeToPrev(true);
+    }
 
+    if (this.lockSwipes) {
+        this.slider.lockSwipes(true);
+    }
+
+    this.refreshView();
+    this.inited = true;
+
+    this.currentDateChangedFromParentSubscription = this.calendarService.currentDateChangedFromParent$.subscribe(currentDate => {
         this.refreshView();
-        this.inited = true;
+    });
 
-        this.currentDateChangedFromParentSubscription = this.calendarService.currentDateChangedFromParent$.subscribe(currentDate => {
-            this.refreshView();
-        });
-
-        this.eventSourceChangedSubscription = this.calendarService.eventSourceChanged$.subscribe(() => {
-            this.onDataLoaded();
-        });
+    this.eventSourceChangedSubscription = this.calendarService.eventSourceChanged$.subscribe(() => {
+        this.onDataLoaded();
+    });
     }
 
     ngOnDestroy() {
@@ -735,3 +744,4 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnChanges
         this.onEventSelected.emit(event);
     }
 }
+


### PR DESCRIPTION
Following the issue 'dynamic locale change' #225, here is a possible solution:
by using a setter on the locale property of the view and executing a refresh of the view in there.

This code is not here to be considered as a serious pull request. It is only for a clearer exemplification.
- The initAndRefresh method was created without much though and analyse on my part
- this type of solution would have to be applied to all the views